### PR TITLE
Upgrade to Spark 3.0.1 with Scala 2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Example metrics.properties snippet:
 
 - This takes a dependency on the Apache2-licensed `com.izettle.dropwizard-metrics-influxdb` library, which is an improved version of Dropwizard's upstream InfluxDb support, which exists only in the DropWizard Metrics 4.0 branch.
 - The package that this code lives in is `org.apache.spark.metrics.sink`, which is necessary because Spark makes its Sink interface package-private.
+- Build this package under Java 8
 
 License
 -------

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 # Project Dependencies
-sparkVersion = 2.3.0
-scalaVersion = 2.11.8
+sparkVersion = 3.0.1
+scalaVersion = 2.12.0
 dwMetricsVersion = 3.2.5
-influxSinkVersion = 1.2.2
+influxSinkVersion = 1.3.3
 
 # Build System
 baselineVersion = 0.19.0

--- a/spark-influx-sink/build.gradle
+++ b/spark-influx-sink/build.gradle
@@ -1,3 +1,5 @@
+version = '0.5.0'
+
 apply plugin: 'scala'
 
 apply plugin: 'com.palantir.baseline-eclipse'
@@ -21,7 +23,7 @@ dependencies {
         // Pulls in 4.x of metrics-core, we want 3.x
         exclude group: 'io.dropwizard.metrics', module: 'metrics-core'
     }
-    compileOnly "org.apache.spark:spark-core_2.11:${sparkVersion}"
+    compileOnly "org.apache.spark:spark-core_2.12:${sparkVersion}"
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
## Before this PR
Doesn't work with Spark 3.x and Scala 2.12

## After this PR
Support for Spark 3.0.1 and Scala 2.12 added

## Possible downsides?


